### PR TITLE
support reCAPTCHA v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "next": "14.0.4",
         "react": "^18",
         "react-dom": "^18",
+        "react-google-recaptcha-v3": "^1.10.1",
         "react-hook-form": "^7.49.2",
         "swr": "^2.2.4"
       },
@@ -2330,6 +2331,14 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
@@ -3654,6 +3663,18 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-google-recaptcha-v3": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/react-google-recaptcha-v3/-/react-google-recaptcha-v3-1.10.1.tgz",
+      "integrity": "sha512-K3AYzSE0SasTn+XvV2tq+6YaxM+zQypk9rbCgG4OVUt7Rh4ze9basIKefoBz9sC0CNslJj9N1uwTTgRMJQbQJQ==",
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "peerDependencies": {
+        "react": "^16.3 || ^17.0 || ^18.0",
+        "react-dom": "^17.0 || ^18.0"
+      }
+    },
     "node_modules/react-hook-form": {
       "version": "7.49.2",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.49.2.tgz",
@@ -3673,8 +3694,7 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/read-cache": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "next": "14.0.4",
     "react": "^18",
     "react-dom": "^18",
+    "react-google-recaptcha-v3": "^1.10.1",
     "react-hook-form": "^7.49.2",
     "swr": "^2.2.4"
   },


### PR DESCRIPTION
This patch adds support for reCAPTCHA v3. It's enabled only when `NEXT_PUBLIC_RECAPTCHA_CLIENT_KEY` envvar is set at compile time. The server-side support has already been introduced by https://github.com/ushitora-anqou/yorksap/commit/fd81a7482ab7ba086260d8c520fe3c097f85fe16.

To uta8a: You don't need to hurry to merge this PR because I'm currently using my forked version.